### PR TITLE
Add new method to implemnt Automatic Frequency Correction

### DIFF
--- a/src/sx126x.h
+++ b/src/sx126x.h
@@ -96,6 +96,7 @@ class Sx126xDriverBase
 
     // Rx methods
     void SetRx(uint32_t tmo_periodbase); // max 24 bit
+    void HandleAFC(void) {}
     void GetPacketStatus(int8_t* RssiSync, int8_t* Snr);
     void GetRxBufferStatus(uint8_t* rxPayloadLength, uint8_t* rxStartBufferPointer);
     void ClearRxEvent(void); // clear any event, if any

--- a/src/sx127x.cpp
+++ b/src/sx127x.cpp
@@ -314,10 +314,10 @@ void Sx127xDriverBase::SetRxTimeout(uint16_t tmo_symbols)
 // Call on Rx side after succesfull receive
 void Sx127xDriverBase::HandleAFC(void)
 {
-  if (CurrFreq && (abs(FreqErrorEst) < ST127x_AFCLimit)) {
-    int sign2 = (ReadRegister(SX1276_REG_FeiMsb) & 0b1000) >> 2; // negative -> 2, positive -> 0
+  if (CurrFreq && (labs(FreqErrorEst) < ST127x_AFCLimit)) {
+    int8_t sign2 = (ReadRegister(SX1276_REG_FeiMsb) & 0b1000) >> 2; // negative -> 2, positive -> 0
     FreqErrorEst -= sign2 - 1; // if error negative -> subtract 1, positive ->  add 1
-    WriteRegister(SX1276_REG_PpmCorrection, FreqErrorEst * 1e6 / 100 * 95 / CurrFreq); // Adjust data rate.  Could avoid write when unchanged
+    WriteRegister(SX1276_REG_PpmCorrection, FreqErrorEst * 950000 / CurrFreq); // Adjust data rate.  This depends on ST127x_AFCLimit to not overflow.
   }
 }
 

--- a/src/sx127x.h
+++ b/src/sx127x.h
@@ -15,8 +15,9 @@
 
 #define SX127X_FREQ_XTAL_HZ               32000000
 
+#define SX127X_FREQ_STEP ((double)SX127X_FREQ_XTAL_HZ / (double)(1<<19)) // 61.03515625 Hz
+#define ST127x_AFCLimit ((int32_t)(100000/SX127X_FREQ_STEP)) // Dimensonless
 #define SX127X_FREQ_MHZ_TO_REG(f_mhz)     (uint32_t)((double)f_mhz*1.0E6*(double)(1 << 19)/(double)SX127X_FREQ_XTAL_HZ)
-
 
 #ifndef ALIGNED
 #define ALIGNED  __attribute__((aligned(4)))
@@ -32,6 +33,9 @@
 
 class Sx127xDriverBase
 {
+  private:
+    uint32_t FreqErrorEst = 0; // In multiples of SX127X_FREQ_STEP.  Should this be reset on connection loss? (I think not)
+    uint32_t CurrFreq = 0;
   public:
     Sx127xDriverBase() {} // constructor
 
@@ -89,6 +93,7 @@ class Sx127xDriverBase
     void SetRxSingle(void);
     void SetRxContinuous(void);
     void SetRxTimeout(uint16_t tmo_symbols);
+    void HandleAFC(void);
     void GetPacketStatus(int16_t* RssiSync, int8_t* Snr);
     void GetRxBufferStatus(uint8_t* rxPayloadLength, uint8_t* rxStartBufferPointer);
 
@@ -142,7 +147,7 @@ typedef enum {
     SX1276_REG_HopPeriod              = 0x24, // 7-0 FreqHoppingPeriod(7:0)
     SX1276_REG_FifoRxByteAddr         = 0x25, // 7-0 FifoRxByteAddrPtr
     SX1276_REG_ModemConfig3           = 0x26, // 3 LowDataRateOptimize, 2 AgcAutoOn
-    SX1280_REG_0x27                   = 0x27, // 7-0 PpmCorrection
+    SX1276_REG_PpmCorrection          = 0x27, // 7-0 PpmCorrection
     SX1276_REG_FeiMsb                 = 0x28, // 3-0 FreqError(19:16)
     SX1276_REG_FeiMid                 = 0x29, // 7-0 FreqError(15:8)
     SX1276_REG_FeiLsb                 = 0x2A, // 7-0 FreqError(7:0)

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -102,6 +102,7 @@ class Sx128xDriverBase
     // Rx methods
 
     void SetRx(uint8_t PeriodBase, uint16_t PeriodBaseCount);
+    void HandleAFC(void) {}
     void GetPacketStatus(int8_t* RssiSync, int8_t* Snr);
     void GetRxBufferStatus(uint8_t* rxPayloadLength, uint8_t* rxStartBufferPointer);
 


### PR DESCRIPTION
This is the bulk of my code changes which implement AFC for the SX127x.  The SX126x doesn't seem to implement these registers so I suspect they may be handling this automatically somehow.  I didn't implement it yet for the SX128x either.
I've not done PRs for a bug which requires changes in both the main repository and a submodule before, so I hope I didn't miss a step.