### PR TITLE
Calibrate Image Helper

### DIFF
--- a/src/sx126x.cpp
+++ b/src/sx126x.cpp
@@ -498,12 +498,12 @@ uint8_t buf[4];
 }
 
 
-void Sx126xDriverBase::CalibrateImage(uint8_t freq1, uint8_t freq2)
+void Sx126xDriverBase::CalibrateImage(uint8_t Freq1, uint8_t Freq2)
 {
 uint8_t buf[2];
 
-    buf[0] = freq1;
-    buf[1] = freq2;
+    buf[0] = Freq1;
+    buf[1] = Freq2;
 
     WriteCommand(SX126X_CMD_CALIBRATE_IMAGE, buf, 2);
 }

--- a/src/sx126x.cpp
+++ b/src/sx126x.cpp
@@ -498,7 +498,7 @@ uint8_t buf[4];
 }
 
 
-void Sx126xDriverBase::imageCalibration(uint8_t freq1, uint8_t freq2)
+void Sx126xDriverBase::CalibrateImage(uint8_t freq1, uint8_t freq2)
 {
 uint8_t buf[2];
 

--- a/src/sx126x.cpp
+++ b/src/sx126x.cpp
@@ -498,5 +498,12 @@ uint8_t buf[4];
 }
 
 
+void imageCalibration(uint8_t freq1, uint8_t freq2)
+{
+uint8_t buf[2];
 
+    buf[0] = freq1;
+    buf[1] = freq2;
 
+    WriteCommand(SX126X_CMD_CALIBRATE_IMAGE, buf, 2);
+}

--- a/src/sx126x.cpp
+++ b/src/sx126x.cpp
@@ -498,7 +498,7 @@ uint8_t buf[4];
 }
 
 
-void imageCalibration(uint8_t freq1, uint8_t freq2)
+void Sx126xDriverBase::imageCalibration(uint8_t freq1, uint8_t freq2)
 {
 uint8_t buf[2];
 

--- a/src/sx126x.h
+++ b/src/sx126x.h
@@ -112,7 +112,7 @@ class Sx126xDriverBase
     void SetPaConfig_22dbm(void);
     void SetRxGain(uint8_t RxGain);
     void SetOverCurrentProtection(uint8_t OverCurrentProtection);
-    void imageCalibration(uint8_t freq1, uint8_t freq2);
+    void CalibrateImage(uint8_t freq1, uint8_t freq2);
 
     // what else we like to have
 

--- a/src/sx126x.h
+++ b/src/sx126x.h
@@ -112,7 +112,7 @@ class Sx126xDriverBase
     void SetPaConfig_22dbm(void);
     void SetRxGain(uint8_t RxGain);
     void SetOverCurrentProtection(uint8_t OverCurrentProtection);
-    void CalibrateImage(uint8_t freq1, uint8_t freq2);
+    void CalibrateImage(uint8_t Freq1, uint8_t Freq2);
 
     // what else we like to have
 
@@ -439,7 +439,7 @@ typedef enum {                                           // table 13-18 p. 75
 //-------------------------------------------------------
 // Image Calibration on specific frequency band
 //-------------------------------------------------------
-// cmd 0x98 CalibrateImage (uint8_t freq1, uint8_t freq2)
+// cmd 0x98 CalibrateImage (uint8_t Freq1, uint8_t Freq2)
 typedef enum {
     SX126X_CAL_IMG_430_MHZ_1             = 0x6B, // table 9-2 p. 57
     SX126X_CAL_IMG_430_MHZ_2             = 0x6F,

--- a/src/sx126x.h
+++ b/src/sx126x.h
@@ -112,6 +112,7 @@ class Sx126xDriverBase
     void SetPaConfig_22dbm(void);
     void SetRxGain(uint8_t RxGain);
     void SetOverCurrentProtection(uint8_t OverCurrentProtection);
+    void imageCalibration(uint8_t freq1, uint8_t freq2);
 
     // what else we like to have
 


### PR DESCRIPTION
Saw that image calibrations isn't done in mLRS sx126x driver, so added this helper to start.  Datasheet notes that this should be called after setting up TCXO and can be told the freqs in use:

![IC Datasheet](https://user-images.githubusercontent.com/41841496/222904279-6fbfda8b-0735-46f8-aa1c-f7c13a13d670.png)

Freqs are also in these defines here: https://github.com/jlpoltrack/sx12xx-lib/blob/main/src/sx126x.h#L442

mLRS driver section: https://github.com/olliw42/mLRS/blob/main/mLRS/Common/sx-drivers/sx126x_driver.h#L160

Let me know what you think and can determine if it makes sense to try and incorporate in driver.