### PR TITLE
SX128x RSSI Calc Update

### DIFF
--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -301,24 +301,24 @@ uint8_t buf[3];
 void Sx128xDriverBase::GetPacketStatus(int8_t* RssiSync, int8_t* Snr)
 {
 uint8_t status[5];
-int16_t rssi_sync_temp;
-int16_t snr_temp;
-int16_t neg_offset;
+int8_t rssi_sync_temp;
+int8_t snr_temp;
+int8_t neg_offset;
 
 // param 3 & 4 & 5 are not used, must read them nevertheless
 
     ReadCommand(SX1280_CMD_GET_PACKET_STATUS, status, 5);
 
-    rssi_sync_temp = -(int16_t)(int8_t)(status[0] / 2);
-    snr_temp = (int16_t)(int8_t)status[1];
+    rssi_sync_temp = -(int8_t)(status[0] / 2);
+    snr_temp = (int8_t)status[1];
 
     neg_offset = (snr_temp < 0) ? (snr_temp / 4) : 0;
 
-    rssi_sync_temp = ((rssi_sync_temp + neg_offset) >= INT8_MIN) ? (rssi_sync_temp + neg_offset) : INT8_MIN
-     
-    *RssiSync = (int8_t)rssi_sync_temp;
+    rssi_sync_temp += neg_offset;
 
-    *Snr = (int8_t)snr_temp / 4;
+    *RssiSync = rssi_sync_temp;
+
+    *Snr = snr_temp / 4;
 
     // datasheet p. 93, table 11-66: If the SNR ≤ 0, RSSI_{packet, real} = RSSI_{packet,measured} – SNR_{measured}
     // datasheet p.134, point 4: Actual SNR in dB =SnrPkt/4 , noting that only negative values should be used.

--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -301,15 +301,22 @@ uint8_t buf[3];
 void Sx128xDriverBase::GetPacketStatus(int8_t* RssiSync, int8_t* Snr)
 {
 uint8_t status[5];
+int8_t RssiSyncTemp;
+int8_t SnrTemp;
+int8_t negOffset;
+
 // param 3 & 4 & 5 are not used, must read them nevertheless
 
     ReadCommand(SX1280_CMD_GET_PACKET_STATUS, status, 5);
 
-    *RssiSync = -(int8_t)(status[0] / 2);
+    RssiSyncTemp = -(int8_t)(status[0] / 2);
+    SnrTemp = (int8_t)status[1];
 
-    *Snr = (int8_t)(status[1] / 4);
-    // https://os.mbed.com/teams/Semtech/code/SX1280Lib/docs/tip/sx1280_8cpp_source.html#l00374:
-    // *Snr = (status[1] < 128) ? (status[1] / 4) : ((status[1] - 256) / 4);
+    negOffset = (SnrTemp < 0) ? (SnrTemp / 4) : 0;
+     
+    *RssiSync = RssiSyncTemp + negOffset;
+
+    *Snr = SnrTemp / 4;
 
     // datasheet p. 93, table 11-66: If the SNR ≤ 0, RSSI_{packet, real} = RSSI_{packet,measured} – SNR_{measured}
     // datasheet p.134, point 4: Actual SNR in dB =SnrPkt/4 , noting that only negative values should be used.

--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -298,27 +298,19 @@ uint8_t buf[3];
 }
 
 
-void Sx128xDriverBase::GetPacketStatus(int8_t* RssiSync, int8_t* Snr)
+void Sx128xDriverBase::GetPacketStatus(int16_t* RssiSync, int8_t* Snr)
 {
 uint8_t status[5];
-int16_t rssi_sync_temp;
-int16_t snr_temp;
-int16_t neg_offset;
 
 // param 3 & 4 & 5 are not used, must read them nevertheless
 
     ReadCommand(SX1280_CMD_GET_PACKET_STATUS, status, 5);
 
-    rssi_sync_temp = -(int16_t)(int8_t)(status[0] / 2);
-    snr_temp = (int16_t)(int8_t)status[1];
-
-    neg_offset = (snr_temp < 0) ? (snr_temp / 4) : 0;
-
-    rssi_sync_temp = ((rssi_sync_temp + neg_offset) >= INT8_MIN) ? (rssi_sync_temp + neg_offset) : INT8_MIN;
-
-    *RssiSync = (int8_t)rssi_sync_temp;
-
-    *Snr = (int8_t)snr_temp / 4;
+    *RssiSync = -(int16_t)(status[0] / 2);
+    *Snr = (int8_t)status[1] / 4;
+    if (*Snr < 0) {
+        *RssiSync += *Snr;
+    }
 
     // datasheet p. 93, table 11-66: If the SNR ≤ 0, RSSI_{packet, real} = RSSI_{packet,measured} – SNR_{measured}
     // datasheet p.134, point 4: Actual SNR in dB =SnrPkt/4 , noting that only negative values should be used.

--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -301,22 +301,24 @@ uint8_t buf[3];
 void Sx128xDriverBase::GetPacketStatus(int8_t* RssiSync, int8_t* Snr)
 {
 uint8_t status[5];
-int8_t RssiSyncTemp;
-int8_t SnrTemp;
-int8_t negOffset;
+int16_t rssi_sync_temp;
+int16_t snr_temp;
+int16_t neg_offset;
 
 // param 3 & 4 & 5 are not used, must read them nevertheless
 
     ReadCommand(SX1280_CMD_GET_PACKET_STATUS, status, 5);
 
-    RssiSyncTemp = -(int8_t)(status[0] / 2);
-    SnrTemp = (int8_t)status[1];
+    rssi_sync_temp = -(int16_t)(int8_t)(status[0] / 2);
+    snr_temp = (int16_t)(int8_t)status[1];
 
-    negOffset = (SnrTemp < 0) ? (SnrTemp / 4) : 0;
+    neg_offset = (snr_temp < 0) ? (snr_temp / 4) : 0;
+
+    rssi_sync_temp = ((rssi_sync_temp + neg_offset) >= INT8_MIN) ? (rssi_sync_temp + neg_offset) : INT8_MIN
      
-    *RssiSync = RssiSyncTemp + negOffset;
+    *RssiSync = (int8_t)rssi_sync_temp;
 
-    *Snr = SnrTemp / 4;
+    *Snr = (int8_t)snr_temp / 4;
 
     // datasheet p. 93, table 11-66: If the SNR ≤ 0, RSSI_{packet, real} = RSSI_{packet,measured} – SNR_{measured}
     // datasheet p.134, point 4: Actual SNR in dB =SnrPkt/4 , noting that only negative values should be used.

--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -301,24 +301,24 @@ uint8_t buf[3];
 void Sx128xDriverBase::GetPacketStatus(int8_t* RssiSync, int8_t* Snr)
 {
 uint8_t status[5];
-int8_t rssi_sync_temp;
-int8_t snr_temp;
-int8_t neg_offset;
+int16_t rssi_sync_temp;
+int16_t snr_temp;
+int16_t neg_offset;
 
 // param 3 & 4 & 5 are not used, must read them nevertheless
 
     ReadCommand(SX1280_CMD_GET_PACKET_STATUS, status, 5);
 
-    rssi_sync_temp = -(int8_t)(status[0] / 2);
-    snr_temp = (int8_t)status[1];
+    rssi_sync_temp = -(int16_t)(int8_t)(status[0] / 2);
+    snr_temp = (int16_t)(int8_t)status[1];
 
     neg_offset = (snr_temp < 0) ? (snr_temp / 4) : 0;
 
-    rssi_sync_temp += neg_offset;
+    rssi_sync_temp = ((rssi_sync_temp + neg_offset) >= INT8_MIN) ? (rssi_sync_temp + neg_offset) : INT8_MIN;
 
-    *RssiSync = rssi_sync_temp;
+    *RssiSync = (int8_t)rssi_sync_temp;
 
-    *Snr = snr_temp / 4;
+    *Snr = (int8_t)snr_temp / 4;
 
     // datasheet p. 93, table 11-66: If the SNR ≤ 0, RSSI_{packet, real} = RSSI_{packet,measured} – SNR_{measured}
     // datasheet p.134, point 4: Actual SNR in dB =SnrPkt/4 , noting that only negative values should be used.

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -102,7 +102,7 @@ class Sx128xDriverBase
     // Rx methods
 
     void SetRx(uint8_t PeriodBase, uint16_t PeriodBaseCount);
-    void GetPacketStatus(int8_t* RssiSync, int8_t* Snr);
+    void GetPacketStatus(int16_t* RssiSync, int8_t* Snr);
     void GetRxBufferStatus(uint8_t* rxPayloadLength, uint8_t* rxStartBufferPointer);
 
     // auxiliary methods


### PR DESCRIPTION
Updates the RSSI calculation to account for when the SNR is negative.

Borrowed logic from Datasheet / ELRS: https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lib/SX1280Driver/SX1280.cpp#L580-L597