### PR TITLE
SX1280 FLRC Initial Work

### DIFF
--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -205,63 +205,6 @@ uint8_t buf[7];
 }
 
 
-void Sx128xDriverBase::SetModulationParamsFLRC(uint8_t Bandwidth, uint8_t CodingRate, uint8_t Bt)
-{
-uint8_t buf[3];
-
-    buf[0] = Bandwidth;
-    buf[1] = CodingRate;
-    buf[2] = Bt;
-
-    WriteCommand(SX1280_CMD_SET_MODULATION_PARAMS, buf, 3);
-}
-
-
-void Sx128xDriverBase::SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
-    uint16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
-{
-uint8_t buf[7];
-
-    buf[0] = AGCPreambleLength;                     // AGC Preamble Length
-    buf[1] = SyncWordLength;                        // Sync Word Length
-    buf[2] = SyncWordMatch;                         // Sync Word Combination
-    buf[3] = PacketType;                            // Packet Type
-    buf[4] = PayloadLength;                         // Payload Length
-    buf[5] = CrcLength;                             // CRC Length
-    buf[6] = 0x08;                                  // Whitening (always disabled for FLRC) table 14-41, p. 125
-
-    WriteCommand(SX1280_CMD_SET_PACKET_PARAMS, buf, 7);
-
-    // CRC Seed
-    buf[0] = (uint8_t)(CrcSeed >> 8);
-    buf[1] = (uint8_t)CrcSeed;
-    
-    WriteRegister(SX1280_REG_CRCInitialValue, buf, 2);
-
-    // Set Sync Word 1
-    buf[0] = (uint8_t)(SyncWord >> 24);
-    buf[1] = (uint8_t)(SyncWord >> 16);
-    buf[2] = (uint8_t)(SyncWord >> 8);
-    buf[3] = (uint8_t)SyncWord;
-
-    // Borrowed from ELRS: https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lib/SX1280Driver/SX1280.cpp#L382
-    // DS_SX1280-1_V3.2.pdf - 16.4 FLRC Modem: Increased PER in FLRC Packets with Synch Word
-    if (((CodingRate == SX1280_FLRC_CR_1_2) || (CodingRate == SX1280_FLRC_CR_3_4)) &&
-        ((buf[0] == 0x8C && buf[1] == 0x38) || (buf[0] == 0x63 && buf[1] == 0x0E)))
-    {
-        uint8_t temp = buf[0];
-        buf[0] = buf[1];
-        buf[1] = temp;
-        // For SX1280_FLRC_CR_3_4 the datasheet also says
-        // "In addition to this the two LSB values XX XX must not be in the range 0x0000 to 0x3EFF"
-        if (CodingRate == SX1280_FLRC_CR_3_4 && buf[3] <= 0x3E)
-            buf[3] |= 0x80; // 0x80 or 0x40 would work
-    }
-
-    WriteRegister(SX1280_REG_FLRCSyncWordAddress1, buf, 4);
-}
-
-
 void Sx128xDriverBase::SetDioIrqParams(uint16_t IrqMask, uint16_t Dio1Mask, uint16_t Dio2Mask, uint16_t Dio3Mask)
 {
 uint8_t buf[8];
@@ -465,5 +408,64 @@ uint32_t fei;
     fei &= (uint32_t)0x0FFFFF;
 
     return fei;
+}
+
+
+// FLRC
+
+void Sx128xDriverBase::SetModulationParamsFLRC(uint8_t Bandwidth, uint8_t CodingRate, uint8_t Bt)
+{
+uint8_t buf[3];
+
+    buf[0] = Bandwidth;
+    buf[1] = CodingRate;
+    buf[2] = Bt;
+
+    WriteCommand(SX1280_CMD_SET_MODULATION_PARAMS, buf, 3);
+}
+
+
+void Sx128xDriverBase::SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
+    uint16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
+{
+uint8_t buf[7];
+
+    buf[0] = AGCPreambleLength;                     // AGC Preamble Length
+    buf[1] = SyncWordLength;                        // Sync Word Length
+    buf[2] = SyncWordMatch;                         // Sync Word Combination
+    buf[3] = PacketType;                            // Packet Type
+    buf[4] = PayloadLength;                         // Payload Length
+    buf[5] = CrcLength;                             // CRC Length
+    buf[6] = 0x08;                                  // Whitening (always disabled for FLRC) table 14-41, p. 125
+
+    WriteCommand(SX1280_CMD_SET_PACKET_PARAMS, buf, 7);
+
+    // CRC Seed
+    buf[0] = (uint8_t)(CrcSeed >> 8);
+    buf[1] = (uint8_t)CrcSeed;
+    
+    WriteRegister(SX1280_REG_CRCInitialValue, buf, 2);
+
+    // Set Sync Word 1
+    buf[0] = (uint8_t)(SyncWord >> 24);
+    buf[1] = (uint8_t)(SyncWord >> 16);
+    buf[2] = (uint8_t)(SyncWord >> 8);
+    buf[3] = (uint8_t)SyncWord;
+
+    // Borrowed from ELRS: https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lib/SX1280Driver/SX1280.cpp#L382
+    // DS_SX1280-1_V3.2.pdf - 16.4 FLRC Modem: Increased PER in FLRC Packets with Synch Word
+    if (((CodingRate == SX1280_FLRC_CR_1_2) || (CodingRate == SX1280_FLRC_CR_3_4)) &&
+        ((buf[0] == 0x8C && buf[1] == 0x38) || (buf[0] == 0x63 && buf[1] == 0x0E)))
+    {
+        uint8_t temp = buf[0];
+        buf[0] = buf[1];
+        buf[1] = temp;
+        // For SX1280_FLRC_CR_3_4 the datasheet also says
+        // "In addition to this the two LSB values XX XX must not be in the range 0x0000 to 0x3EFF"
+        if (CodingRate == SX1280_FLRC_CR_3_4 && buf[3] <= 0x3E)
+            buf[3] |= 0x80; // 0x80 or 0x40 would work
+    }
+
+    WriteRegister(SX1280_REG_FLRCSyncWordAddress1, buf, 4);
 }
 

--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -466,6 +466,6 @@ uint8_t buf[7];
             buf[3] |= 0x80; // 0x80 or 0x40 would work
     }
 
-    WriteRegister(SX1280_REG_FLRCSyncWordAddress1, buf, 4);
+    WriteRegister(SX1280_REG_FLRC_SyncWordAddress1, buf, 4);
 }
 

--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -217,16 +217,17 @@ uint8_t buf[3];
 }
 
 
-void Sx128xDriverBase::SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t PacketType, uint8_t PayloadLength, int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
+void Sx128xDriverBase::SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
+    int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
 {
 uint8_t buf[7];
 
     buf[0] = AGCPreambleLength;                     // AGC Preamble Length
-    buf[1] = SX1280_FLRC_SYNC_WORD_LEN_P32S;        // Sync Word Length
-    buf[2] = SX1280_FLRC_RX_MATCH_SYNC_WORD_1;      // Sync Word Match
+    buf[1] = SyncWordLength;                        // Sync Word Length
+    buf[2] = SyncWordMatch;                         // Sync Word Combination
     buf[3] = PacketType;                            // Packet Type
     buf[4] = PayloadLength;                         // Payload Length
-    buf[5] = SX1280_FLRC_CRC_4_BYTE;                // CRC Length
+    buf[5] = CrcLength;                             // CRC Length
     buf[6] = 0x08;                                  // Whitening (always disabled for FLRC) table 14-41, p. 125
 
     WriteCommand(SX1280_CMD_SET_PACKET_PARAMS, buf, 7);

--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -204,6 +204,7 @@ uint8_t buf[7];
     WriteCommand(SX1280_CMD_SET_PACKET_PARAMS, buf, 7);
 }
 
+
 void Sx128xDriverBase::SetModulationParamsFLRC(uint8_t Bandwidth, uint8_t CodingRate, uint8_t Bt)
 {
 uint8_t buf[3];
@@ -214,6 +215,7 @@ uint8_t buf[3];
 
     WriteCommand(SX1280_CMD_SET_MODULATION_PARAMS, buf, 3);
 }
+
 
 void Sx128xDriverBase::SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t PacketType, uint8_t PayloadLength, int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
 {

--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -218,7 +218,7 @@ uint8_t buf[3];
 
 
 void Sx128xDriverBase::SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
-    int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
+    uint16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
 {
 uint8_t buf[7];
 
@@ -258,7 +258,7 @@ uint8_t buf[7];
             buf[3] |= 0x80; // 0x80 or 0x40 would work
     }
 
-    WriteRegister(SX1280_REG_FLRCSyncWord, buf, 4);
+    WriteRegister(SX1280_REG_FLRCSyncWordAddress1, buf, 4);
 }
 
 
@@ -466,11 +466,4 @@ uint32_t fei;
 
     return fei;
 }
-
-
-
-
-
-
-
 

--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -204,6 +204,60 @@ uint8_t buf[7];
     WriteCommand(SX1280_CMD_SET_PACKET_PARAMS, buf, 7);
 }
 
+void Sx128xDriverBase::SetModulationParamsFLRC(uint8_t Bandwidth, uint8_t CodingRate, uint8_t Bt)
+{
+uint8_t buf[3];
+
+    buf[0] = Bandwidth;
+    buf[1] = CodingRate;
+    buf[2] = Bt;
+
+    WriteCommand(SX1280_CMD_SET_MODULATION_PARAMS, buf, 3);
+}
+
+void Sx128xDriverBase::SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t PacketType, uint8_t PayloadLength, int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
+{
+uint8_t buf[7];
+
+    buf[0] = AGCPreambleLength;                     // AGC Preamble Length
+    buf[1] = SX1280_FLRC_SYNC_WORD_LEN_P32S;        // Sync Word Length
+    buf[2] = SX1280_FLRC_RX_MATCH_SYNC_WORD_1;      // Sync Word Match
+    buf[3] = PacketType;                            // Packet Type
+    buf[4] = PayloadLength;                         // Payload Length
+    buf[5] = SX1280_FLRC_CRC_4_BYTE;                // CRC Length
+    buf[6] = 0x08;                                  // Whitening (always disabled for FLRC) table 14-41, p. 125
+
+    WriteCommand(SX1280_CMD_SET_PACKET_PARAMS, buf, 7);
+
+    // CRC Seed
+    buf[0] = (uint8_t)(CrcSeed >> 8);
+    buf[1] = (uint8_t)CrcSeed;
+    
+    WriteCommand(SX1280_REG_CRCInitialValue, buf, 2);
+
+    // Set Sync Word 1
+    buf[0] = (uint8_t)(SyncWord >> 24);
+    buf[1] = (uint8_t)(SyncWord >> 16);
+    buf[2] = (uint8_t)(SyncWord >> 8);
+    buf[3] = (uint8_t)SyncWord;
+
+    // Borrowed from ELRS: https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lib/SX1280Driver/SX1280.cpp#L382
+    // DS_SX1280-1_V3.2.pdf - 16.4 FLRC Modem: Increased PER in FLRC Packets with Synch Word
+    if (((CodingRate == SX1280_FLRC_CR_1_2) || (CodingRate == SX1280_FLRC_CR_3_4)) &&
+        ((buf[0] == 0x8C && buf[1] == 0x38) || (buf[0] == 0x63 && buf[1] == 0x0E)))
+    {
+        uint8_t temp = buf[0];
+        buf[0] = buf[1];
+        buf[1] = temp;
+        // For SX1280_FLRC_CR_3_4 the datasheet also says
+        // "In addition to this the two LSB values XX XX must not be in the range 0x0000 to 0x3EFF"
+        if (CodingRate == SX1280_FLRC_CR_3_4 && buf[3] <= 0x3E)
+            buf[3] |= 0x80; // 0x80 or 0x40 would work
+    }
+
+    WriteCommand(SX1280_REG_FLRCSyncWord, buf, 4);
+}
+
 
 void Sx128xDriverBase::SetDioIrqParams(uint16_t IrqMask, uint16_t Dio1Mask, uint16_t Dio2Mask, uint16_t Dio3Mask)
 {

--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -236,7 +236,7 @@ uint8_t buf[7];
     buf[0] = (uint8_t)(CrcSeed >> 8);
     buf[1] = (uint8_t)CrcSeed;
     
-    WriteCommand(SX1280_REG_CRCInitialValue, buf, 2);
+    WriteRegister(SX1280_REG_CRCInitialValue, buf, 2);
 
     // Set Sync Word 1
     buf[0] = (uint8_t)(SyncWord >> 24);
@@ -258,7 +258,7 @@ uint8_t buf[7];
             buf[3] |= 0x80; // 0x80 or 0x40 would work
     }
 
-    WriteCommand(SX1280_REG_FLRCSyncWord, buf, 4);
+    WriteRegister(SX1280_REG_FLRCSyncWord, buf, 4);
 }
 
 

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -209,9 +209,9 @@ typedef enum {
     SX1280_REG_SyncAddress1               = 0x9CE, // 5 bytes Synch Word 1 (Also used as the BLE Access Address)
     SX1280_REG_SyncAddress2               = 0x9D3, // 5 bytes SyncWord 2
     SX1280_REG_SyncAddress3               = 0x9D8, // 5 bytes SyncWord 3
-    SX1280_REG_FLRCSyncWordAddress1       = 0x9CF, // 4 bytes SyncWord 1 for FLRC
-    SX1280_REG_FLRCSyncWordAddress2       = 0x9D4, // 4 bytes SyncWord 2 for FLRC
-    SX1280_REG_FLRCSyncWordAddress3       = 0x9D9, // 4 bytes SyncWord 3 for FLRC
+    SX1280_REG_FLRC_SyncWordAddress1      = 0x9CF, // 4 bytes SyncWord 1 for FLRC
+    SX1280_REG_FLRC_SyncWordAddress2      = 0x9D4, // 4 bytes SyncWord 2 for FLRC
+    SX1280_REG_FLRC_SyncWordAddress3      = 0x9D9, // 4 bytes SyncWord 3 for FLRC
 } SX1280_REG_ENUM;
 
 
@@ -308,91 +308,6 @@ typedef enum {
     SX1280_LORA_IQ_NORMAL                 = 0x40, // table 14-54, p. 133
     SX1280_LORA_IQ_INVERTED               = 0x00,
 } SX1280_LORA_IQMODE_ENUM;
-
-
-// cmd 0x8B SetModulationParamsFLRC(uint8_t Bandwidth, uint8_t CodingRate, uint8_t Bt)
-typedef enum
-{
-    SX1280_FLRC_BR_1_300_BW_1_2 = 0x45,
-    SX1280_FLRC_BR_1_000_BW_1_2 = 0x69,
-    SX1280_FLRC_BR_0_650_BW_0_6 = 0x86,
-    SX1280_FLRC_BR_0_520_BW_0_6 = 0xAA,
-    SX1280_FLRC_BR_0_325_BW_0_3 = 0xC7,
-    SX1280_FLRC_BR_0_260_BW_0_3 = 0xEB,
-} SX1280_FLRC_BW_ENUM;
-
-typedef enum
-{
-    SX1280_FLRC_CR_1_2 = 0x00,
-    SX1280_FLRC_CR_3_4 = 0x02,
-    SX1280_FLRC_CR_1_0 = 0x04,
-} SX1280_FLRC_CR_ENUM;
-
-typedef enum
-{
-    SX1280_FLRC_BT_DIS  = 0x00,
-    SX1280_FLRC_BT_1    = 0x10,
-    SX1280_FLRC_BT_0_5  = 0x20,
-} SX1280_FLRC_GAUSSIAN_FILTER_ENUM;
-
-
-// cmd 0x8C SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
-// uint16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
-typedef enum
-{
-    SX1280_PREAMBLE_LENGTH_04_BITS = 0x00, //!< Preamble length: 04 bits (Reserved)
-    SX1280_PREAMBLE_LENGTH_08_BITS = 0x10, //!< Preamble length: 08 bits
-    SX1280_PREAMBLE_LENGTH_12_BITS = 0x20, //!< Preamble length: 12 bits
-    SX1280_PREAMBLE_LENGTH_16_BITS = 0x30, //!< Preamble length: 16 bits
-    SX1280_PREAMBLE_LENGTH_20_BITS = 0x40, //!< Preamble length: 20 bits
-    SX1280_PREAMBLE_LENGTH_24_BITS = 0x50, //!< Preamble length: 24 bits
-    SX1280_PREAMBLE_LENGTH_28_BITS = 0x60, //!< Preamble length: 28 bits
-    SX1280_PREAMBLE_LENGTH_32_BITS = 0x70, //!< Preamble length: 32 bits
-} SX1280_FLRC_PREAMBLE_LENGTH_ENUM;
-
-typedef enum
-{
-    SX1280_FLRC_SYNC_NOSYNC        = 0x00,
-    SX1280_FLRC_SYNC_WORD_LEN_P32S = 0x04,
-} SX1280_FLRC_SYNC_WORD_LENGTH_ENUM;
-
-typedef enum
-{
-    SX1280_FLRC_RX_DISABLE_SYNC_WORD     = 0x00,
-    SX1280_FLRC_RX_MATCH_SYNC_WORD_1     = 0x10,
-    SX1280_FLRC_RX_MATCH_SYNC_WORD_2     = 0x20,
-    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_2   = 0x30,
-    SX1280_FLRC_RX_MATCH_SYNC_WORD_3     = 0x40,
-    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_3   = 0x50,
-    SX1280_FLRC_RX_MATCH_SYNC_WORD_2_3   = 0x60,
-    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_2_3 = 0x70,
-} SX1280_FLRC_SYNC_WORD_COMBINATION_ENUM;
-
-typedef enum
-{
-    SX1280_FLRC_PACKET_FIXED_LENGTH    = 0x00,
-    SX1280_FLRC_PACKET_VARIABLE_LENGTH = 0x20,
-} SX1280_FLRC_PACKET_TYPE_ENUM;
-
-typedef enum
-{
-    SX1280_FLRC_CRC_OFF    = 0x00,
-    SX1280_FLRC_CRC_2_BYTE = 0x10,
-    SX1280_FLRC_CRC_3_BYTE = 0x20,
-    SX1280_FLRC_CRC_4_BYTE = 0x30,
-} SX1280_FLRC_CRC_DEFINITION_ENUM;
-
-enum
-{
-    // FLRC Error Packet Status
-    SX1280_FLRC_PKT_ERROR_BUSY      = 1 << 0,
-    SX1280_FLRC_PKT_ERROR_PKT_RCVD  = 1 << 1,
-    SX1280_FLRC_PKT_ERROR_HDR_RCVD  = 1 << 2,
-    SX1280_FLRC_PKT_ERROR_ABORT     = 1 << 3,
-    SX1280_FLRC_PKT_ERROR_CRC       = 1 << 4,
-    SX1280_FLRC_PKT_ERROR_LENGTH    = 1 << 5,
-    SX1280_FLRC_PKT_ERROR_SYNC      = 1 << 6,
-};
 
 
 // cmd 0x8D SetDioIrqParams(uint16_t IrqMask, uint16_t Dio1Mask, uint16_t Dio2Mask, uint16_t Dio3Mask)
@@ -501,6 +416,94 @@ typedef enum {
   SX1280_LNAGAIN_MODE_HIGH_SENSITIVITY    = 0x01,
 } SX1280_LNAGAIN_MODE_ENUM;
 
+//-------------------------------------------------------
+// FLRC
+//-------------------------------------------------------
+
+// cmd 0x8B SetModulationParamsFLRC(uint8_t Bandwidth, uint8_t CodingRate, uint8_t Bt)
+typedef enum
+{
+    SX1280_FLRC_BR_1_300_BW_1_2 = 0x45,
+    SX1280_FLRC_BR_1_000_BW_1_2 = 0x69,
+    SX1280_FLRC_BR_0_650_BW_0_6 = 0x86,
+    SX1280_FLRC_BR_0_520_BW_0_6 = 0xAA,
+    SX1280_FLRC_BR_0_325_BW_0_3 = 0xC7,
+    SX1280_FLRC_BR_0_260_BW_0_3 = 0xEB,
+} SX1280_FLRC_BW_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_CR_1_2 = 0x00,
+    SX1280_FLRC_CR_3_4 = 0x02,
+    SX1280_FLRC_CR_1_0 = 0x04,
+} SX1280_FLRC_CR_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_BT_DIS  = 0x00,
+    SX1280_FLRC_BT_1    = 0x10,
+    SX1280_FLRC_BT_0_5  = 0x20,
+} SX1280_FLRC_GAUSSIAN_FILTER_ENUM;
+
+
+// cmd 0x8C SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, 
+// uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
+// uint16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
+typedef enum
+{
+    SX1280_FLRC_PREAMBLE_LENGTH_04_BITS = 0x00, //!< Preamble length: 04 bits (Reserved)
+    SX1280_FLRC_PREAMBLE_LENGTH_08_BITS = 0x10, //!< Preamble length: 08 bits
+    SX1280_FLRC_PREAMBLE_LENGTH_12_BITS = 0x20, //!< Preamble length: 12 bits
+    SX1280_FLRC_PREAMBLE_LENGTH_16_BITS = 0x30, //!< Preamble length: 16 bits
+    SX1280_FLRC_PREAMBLE_LENGTH_20_BITS = 0x40, //!< Preamble length: 20 bits
+    SX1280_FLRC_PREAMBLE_LENGTH_24_BITS = 0x50, //!< Preamble length: 24 bits
+    SX1280_FLRC_PREAMBLE_LENGTH_28_BITS = 0x60, //!< Preamble length: 28 bits
+    SX1280_FLRC_PREAMBLE_LENGTH_32_BITS = 0x70, //!< Preamble length: 32 bits
+} SX1280_FLRC_PREAMBLE_LENGTH_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_SYNC_NOSYNC        = 0x00,
+    SX1280_FLRC_SYNC_WORD_LEN_P32S = 0x04,
+} SX1280_FLRC_SYNC_WORD_LENGTH_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_RX_DISABLE_SYNC_WORD     = 0x00,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1     = 0x10,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_2     = 0x20,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_2   = 0x30,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_3     = 0x40,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_3   = 0x50,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_2_3   = 0x60,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_2_3 = 0x70,
+} SX1280_FLRC_SYNC_WORD_COMBINATION_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_PACKET_FIXED_LENGTH    = 0x00,
+    SX1280_FLRC_PACKET_VARIABLE_LENGTH = 0x20,
+} SX1280_FLRC_PACKET_TYPE_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_CRC_OFF    = 0x00,
+    SX1280_FLRC_CRC_2_BYTE = 0x10,
+    SX1280_FLRC_CRC_3_BYTE = 0x20,
+    SX1280_FLRC_CRC_4_BYTE = 0x30,
+} SX1280_FLRC_CRC_DEFINITION_ENUM;
+
+enum
+{
+    // FLRC Error Packet Status
+    SX1280_FLRC_PKT_ERROR_BUSY      = 1 << 0,
+    SX1280_FLRC_PKT_ERROR_PKT_RCVD  = 1 << 1,
+    SX1280_FLRC_PKT_ERROR_HDR_RCVD  = 1 << 2,
+    SX1280_FLRC_PKT_ERROR_ABORT     = 1 << 3,
+    SX1280_FLRC_PKT_ERROR_CRC       = 1 << 4,
+    SX1280_FLRC_PKT_ERROR_LENGTH    = 1 << 5,
+    SX1280_FLRC_PKT_ERROR_SYNC      = 1 << 6,
+};
 
 
 #endif // SX128X_LIB_H

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -89,8 +89,9 @@ class Sx128xDriverBase
     void SetModulationParams(uint8_t SpreadingFactor, uint8_t Bandwidth, uint8_t CodingRate);
     void SetPacketParams(uint8_t PreambleLength, uint8_t HeaderType, uint8_t PayloadLength, uint8_t Crc, uint8_t InvertIQ);
     void SetModulationParamsFLRC(uint8_t Bandwidth, uint8_t CodingRate, uint8_t Bt);
-    void SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
-        int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate);
+    void SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, 
+        uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
+        uint16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate);
 
     void SetDioIrqParams(uint16_t IrqMask, uint16_t Dio1Mask, uint16_t Dio2Mask, uint16_t Dio3Mask);
     uint16_t GetIrqStatus(void);
@@ -336,7 +337,7 @@ typedef enum
 
 
 // cmd 0x8C SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
-// int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
+// uint16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
 typedef enum
 {
     SX1280_PREAMBLE_LENGTH_04_BITS = 0x00, //!< Preamble length: 04 bits (Reserved)

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -88,6 +88,8 @@ class Sx128xDriverBase
     void SetBufferBaseAddress(uint8_t txBaseAdress, uint8_t rxBaseAdress);
     void SetModulationParams(uint8_t SpreadingFactor, uint8_t Bandwidth, uint8_t CodingRate);
     void SetPacketParams(uint8_t PreambleLength, uint8_t HeaderType, uint8_t PayloadLength, uint8_t Crc, uint8_t InvertIQ);
+    void SetModulationParamsFLRC(uint8_t Bandwidth, uint8_t CodingRate, uint8_t Bt);
+    void SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t PacketType, uint8_t PayloadLength, int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate);
 
     void SetDioIrqParams(uint16_t IrqMask, uint16_t Dio1Mask, uint16_t Dio2Mask, uint16_t Dio3Mask);
     uint16_t GetIrqStatus(void);
@@ -205,6 +207,7 @@ typedef enum {
     SX1280_REG_SyncAddress1               = 0x9CE, // 5 bytes Synch Word 1 (Also used as the BLE Access Address)
     SX1280_REG_SyncAddress2               = 0x9D3, // 5 bytes SyncWord 2
     SX1280_REG_SyncAddress3               = 0x9D8, // 5 bytes SyncWord 3
+    SX1280_REG_FLRCSyncWord               = 0x9CF, // 4 bytes SyncWord 1
 } SX1280_REG_ENUM;
 
 
@@ -301,6 +304,90 @@ typedef enum {
     SX1280_LORA_IQ_NORMAL                 = 0x40, // table 14-54, p. 133
     SX1280_LORA_IQ_INVERTED               = 0x00,
 } SX1280_LORA_IQMODE_ENUM;
+
+
+// cmd 0x8B SetModulationParamsFLRC(uint8_t Bandwidth, uint8_t CodingRate, uint8_t Bt)
+typedef enum
+{
+    SX1280_FLRC_BR_1_300_BW_1_2 = 0x45,
+    SX1280_FLRC_BR_1_000_BW_1_2 = 0x69,
+    SX1280_FLRC_BR_0_650_BW_0_6 = 0x86,
+    SX1280_FLRC_BR_0_520_BW_0_6 = 0xAA,
+    SX1280_FLRC_BR_0_325_BW_0_3 = 0xC7,
+    SX1280_FLRC_BR_0_260_BW_0_3 = 0xEB,
+} SX1280_FLRC_BW_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_CR_1_2 = 0x00,
+    SX1280_FLRC_CR_3_4 = 0x02,
+    SX1280_FLRC_CR_1_0 = 0x04,
+} SX1280_FLRC_CR_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_BT_DIS  = 0x00,
+    SX1280_FLRC_BT_1    = 0x10,
+    SX1280_FLRC_BT_0_5  = 0x20,
+} SX1280_FLRC_GAUSSIAN_FILTER_ENUM;
+
+
+// cmd 0x8C SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t PacketType, uint8_t PayloadLength, int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
+typedef enum
+{
+    SX1280_PREAMBLE_LENGTH_04_BITS = 0x00, //!< Preamble length: 04 bits (Reserved)
+    SX1280_PREAMBLE_LENGTH_08_BITS = 0x10, //!< Preamble length: 08 bits
+    SX1280_PREAMBLE_LENGTH_12_BITS = 0x20, //!< Preamble length: 12 bits
+    SX1280_PREAMBLE_LENGTH_16_BITS = 0x30, //!< Preamble length: 16 bits
+    SX1280_PREAMBLE_LENGTH_20_BITS = 0x40, //!< Preamble length: 20 bits
+    SX1280_PREAMBLE_LENGTH_24_BITS = 0x50, //!< Preamble length: 24 bits
+    SX1280_PREAMBLE_LENGTH_28_BITS = 0x60, //!< Preamble length: 28 bits
+    SX1280_PREAMBLE_LENGTH_32_BITS = 0x70, //!< Preamble length: 32 bits
+} SX1280_FLRC_PREAMBLE_LENGTH_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_SYNC_NOSYNC        = 0x00,
+    SX1280_FLRC_SYNC_WORD_LEN_P32S = 0x04,
+} SX1280_FLRC_SYNC_WORD_LENGTH_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_RX_DISABLE_SYNC_WORD     = 0x00,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1     = 0x10,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_2     = 0x20,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_2   = 0x30,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_3     = 0x40,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_3   = 0x50,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_2_3   = 0x60,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_2_3 = 0x70,
+} SX1280_FLRC_SYNC_WORD_COMBINATION_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_PACKET_FIXED_LENGTH    = 0x00,
+    SX1280_FLRC_PACKET_VARIABLE_LENGTH = 0x20,
+} SX1280_FLRC_PACKET_TYPE_ENUM;
+
+typedef enum
+{
+    SX1280_FLRC_CRC_OFF    = 0x00,
+    SX1280_FLRC_CRC_2_BYTE = 0x10,
+    SX1280_FLRC_CRC_3_BYTE = 0x20,
+    SX1280_FLRC_CRC_4_BYTE = 0x30,
+} SX1280_FLRC_CRC_DEFINITION_ENUM;
+
+enum
+{
+    // FLRC Error Packet Status
+    SX1280_FLRC_PKT_ERROR_BUSY      = 1 << 0,
+    SX1280_FLRC_PKT_ERROR_PKT_RCVD  = 1 << 1,
+    SX1280_FLRC_PKT_ERROR_HDR_RCVD  = 1 << 2,
+    SX1280_FLRC_PKT_ERROR_ABORT     = 1 << 3,
+    SX1280_FLRC_PKT_ERROR_CRC       = 1 << 4,
+    SX1280_FLRC_PKT_ERROR_LENGTH    = 1 << 5,
+    SX1280_FLRC_PKT_ERROR_SYNC      = 1 << 6,
+};
 
 
 // cmd 0x8D SetDioIrqParams(uint16_t IrqMask, uint16_t Dio1Mask, uint16_t Dio2Mask, uint16_t Dio3Mask)

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -89,7 +89,8 @@ class Sx128xDriverBase
     void SetModulationParams(uint8_t SpreadingFactor, uint8_t Bandwidth, uint8_t CodingRate);
     void SetPacketParams(uint8_t PreambleLength, uint8_t HeaderType, uint8_t PayloadLength, uint8_t Crc, uint8_t InvertIQ);
     void SetModulationParamsFLRC(uint8_t Bandwidth, uint8_t CodingRate, uint8_t Bt);
-    void SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t PacketType, uint8_t PayloadLength, int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate);
+    void SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
+        int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate);
 
     void SetDioIrqParams(uint16_t IrqMask, uint16_t Dio1Mask, uint16_t Dio2Mask, uint16_t Dio3Mask);
     uint16_t GetIrqStatus(void);
@@ -207,7 +208,9 @@ typedef enum {
     SX1280_REG_SyncAddress1               = 0x9CE, // 5 bytes Synch Word 1 (Also used as the BLE Access Address)
     SX1280_REG_SyncAddress2               = 0x9D3, // 5 bytes SyncWord 2
     SX1280_REG_SyncAddress3               = 0x9D8, // 5 bytes SyncWord 3
-    SX1280_REG_FLRCSyncWord               = 0x9CF, // 4 bytes SyncWord 1
+    SX1280_REG_FLRCSyncWordAddress1       = 0x9CF, // 4 bytes SyncWord 1 for FLRC
+    SX1280_REG_FLRCSyncWordAddress2       = 0x9D4, // 4 bytes SyncWord 2 for FLRC
+    SX1280_REG_FLRCSyncWordAddress3       = 0x9D9, // 4 bytes SyncWord 3 for FLRC
 } SX1280_REG_ENUM;
 
 
@@ -332,7 +335,8 @@ typedef enum
 } SX1280_FLRC_GAUSSIAN_FILTER_ENUM;
 
 
-// cmd 0x8C SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t PacketType, uint8_t PayloadLength, int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
+// cmd 0x8C SetPacketParamsFLRC(uint8_t AGCPreambleLength, uint8_t SyncWordLength, uint8_t SyncWordMatch, uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength, 
+// int16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate)
 typedef enum
 {
     SX1280_PREAMBLE_LENGTH_04_BITS = 0x00, //!< Preamble length: 04 bits (Reserved)


### PR DESCRIPTION
Motivation: FLRC offers a lot more throughput at similar sensitivities to LoRa SF5 (currently used for 50 Hz)

Example:

- 0.65 Mb/s, Code Rate 1/2
- Sensitivity: -104 dBm (-105 dBM for LoRa SF5)
- OTA: 2.48 ms
- 100 Hz possible ? : 6,400 Bytes Uplink, 8,200 Bytes Downlink

![image](https://github.com/olliw42/sx12xx-lib/assets/41841496/ba017254-8ee3-490b-b8df-2e461bbcb099)

