### PR TITLE
Error packet typedef enum

### DIFF
--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -492,7 +492,7 @@ typedef enum {
 
 
 // FLRC error packet status
-enum {
+typedef enum {
     SX1280_FLRC_PACKET_ERROR_BUSY         = 0x01,
     SX1280_FLRC_PACKET_ERROR_PKT_RCVD     = 0x02,
     SX1280_FLRC_PACKET_ERROR_HDR_RCVD     = 0x04,


### PR DESCRIPTION
Update to typedef enum, stops compiler warning.