### PR TITLE
flrc sync word tolerance

### DIFF
--- a/src/sx128x.cpp
+++ b/src/sx128x.cpp
@@ -483,3 +483,12 @@ uint8_t status[5];
     *RssiSync = -(int16_t)(status[0] / 2);
 }
 
+void Sx128xDriverBase::SetSyncWordErrorToleranceFLRC(uint8_t ErrorBits)
+{
+uint8_t tolerance;
+
+	tolerance = ReadRegister(SX1280_REG_FLRC_SyncAddressControl);
+	tolerance = (tolerance & 0xF0) | (ErrorBits & 0x0F);  // Preserve upper 4 bits, update lower 4 bits
+	WriteRegister(SX1280_REG_FLRC_SyncAddressControl, tolerance);
+}
+

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -128,7 +128,7 @@ class Sx128xDriverBase
         uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength,
         uint16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate);
     void GetPacketStatusFLRC(int16_t* RssiSync);
-    void SetSyncWordErrorToleranceFLRC(uint8_t errorBits);
+    void SetSyncWordErrorToleranceFLRC(uint8_t ErrorBits);
 
   private:
     uint8_t _status; // all spi transfers yield the status, so we can just get it

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -211,14 +211,13 @@ typedef enum {
     SX1280_REG_CRCPolynomialDefinition    = 0x9C6, // 2 bytes CRC Polynomial Definition for GFSK.
     SX1280_REG_CRCPolynomialSeed          = 0x9C7, // 3 bytes CRC Seed for BLE modulation.
     SX1280_REG_CRCInitialValue            = 0x9C8, // 2 bytes CRC Seed used for GFSK and FLRC modulation.
-    SX1280_REG_SynchAddressControl        = 0x9CD, // 0:3 rw 0x80 The number of synch word bit errors tolerated in FLRC and GFSK modes
     SX1280_REG_SyncAddress1               = 0x9CE, // 5 bytes Synch Word 1 (Also used as the BLE Access Address)
     SX1280_REG_SyncAddress2               = 0x9D3, // 5 bytes SyncWord 2
     SX1280_REG_SyncAddress3               = 0x9D8, // 5 bytes SyncWord 3
     SX1280_REG_FLRC_SyncWordAddress1      = 0x9CF, // 4 bytes SyncWord 1 for FLRC
     SX1280_REG_FLRC_SyncWordAddress2      = 0x9D4, // 4 bytes SyncWord 2 for FLRC
     SX1280_REG_FLRC_SyncWordAddress3      = 0x9D9, // 4 bytes SyncWord 3 for FLRC
-    SX1280_REG_FLRC_SyncAddressControl    = 0x9CD, // 0:3 rw 0x80 Sync work bit errors for FLRC
+    SX1280_REG_FLRC_SyncAddressControl    = 0x9CD, // 0:3 rw 0x80 Sync word bit errors for FLRC
 } SX1280_REG_ENUM;
 
 

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -217,7 +217,7 @@ typedef enum {
     SX1280_REG_FLRC_SyncWordAddress1      = 0x9CF, // 4 bytes SyncWord 1 for FLRC
     SX1280_REG_FLRC_SyncWordAddress2      = 0x9D4, // 4 bytes SyncWord 2 for FLRC
     SX1280_REG_FLRC_SyncWordAddress3      = 0x9D9, // 4 bytes SyncWord 3 for FLRC
-    SX1280_REG_FLRC_SyncAddressControl    = 0x9CD, // 0:3 rw 0x80 Sync word bit errors for FLRC
+    SX1280_REG_FLRC_SyncAddressControl    = 0x9CD, // 0:3 rw 0x80 The number of synch word bit errors tolerated in FLRC and GFSK modes
 } SX1280_REG_ENUM;
 
 

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -128,6 +128,7 @@ class Sx128xDriverBase
         uint8_t PacketType, uint8_t PayloadLength, uint8_t CrcLength,
         uint16_t CrcSeed, uint32_t SyncWord, uint8_t CodingRate);
     void GetPacketStatusFLRC(int16_t* RssiSync);
+    void SetSyncWordErrorToleranceFLRC(uint8_t errorBits);
 
   private:
     uint8_t _status; // all spi transfers yield the status, so we can just get it
@@ -217,6 +218,7 @@ typedef enum {
     SX1280_REG_FLRC_SyncWordAddress1      = 0x9CF, // 4 bytes SyncWord 1 for FLRC
     SX1280_REG_FLRC_SyncWordAddress2      = 0x9D4, // 4 bytes SyncWord 2 for FLRC
     SX1280_REG_FLRC_SyncWordAddress3      = 0x9D9, // 4 bytes SyncWord 3 for FLRC
+	SX1280_REG_FLRC_SyncAddressControl    = 0x9CD, // 0:3 rw 0x80 Sync work bit errors for FLRC
 } SX1280_REG_ENUM;
 
 

--- a/src/sx128x.h
+++ b/src/sx128x.h
@@ -218,7 +218,7 @@ typedef enum {
     SX1280_REG_FLRC_SyncWordAddress1      = 0x9CF, // 4 bytes SyncWord 1 for FLRC
     SX1280_REG_FLRC_SyncWordAddress2      = 0x9D4, // 4 bytes SyncWord 2 for FLRC
     SX1280_REG_FLRC_SyncWordAddress3      = 0x9D9, // 4 bytes SyncWord 3 for FLRC
-	SX1280_REG_FLRC_SyncAddressControl    = 0x9CD, // 0:3 rw 0x80 Sync work bit errors for FLRC
+    SX1280_REG_FLRC_SyncAddressControl    = 0x9CD, // 0:3 rw 0x80 Sync work bit errors for FLRC
 } SX1280_REG_ENUM;
 
 


### PR DESCRIPTION
Add function to adjust FLRC sync word error tolerance (how many error bits are allowed in the sync word).  No use case for - just to make this more complete.

Code borrowed from: https://os.mbed.com/teams/Semtech/code/SX1280Lib//file/c4f110f3fe3e/sx1280.cpp/