### PR TITLE
sx127x-rssi-neg-snr

### DIFF
--- a/src/sx127x.cpp
+++ b/src/sx127x.cpp
@@ -340,6 +340,12 @@ void Sx127xDriverBase::GetPacketStatus(int16_t* RssiSync, int8_t* Snr)
 {
     *RssiSync = (int16_t)-157 + ReadRegister(SX1276_REG_PktRssiValue);
     *Snr = (int8_t)ReadRegister(SX1276_REG_PktSnrValue) / 4;
+    
+    // Datasheet 3.5.5, need to subtract SNR (PacketSnr 4) when SNR is negative
+    if (*Snr < 0) {
+        *RssiSync += *Snr;
+    }
+
 }
 
 

--- a/src/sx127x.cpp
+++ b/src/sx127x.cpp
@@ -341,7 +341,7 @@ void Sx127xDriverBase::GetPacketStatus(int16_t* RssiSync, int8_t* Snr)
     *RssiSync = (int16_t)-157 + ReadRegister(SX1276_REG_PktRssiValue);
     *Snr = (int8_t)ReadRegister(SX1276_REG_PktSnrValue) / 4;
     
-    // Datasheet 3.5.5, need to subtract SNR (PacketSnr 4) when SNR is negative
+    // Datasheet 3.5.5, need to subtract SNR (PacketSnr / 4) when SNR is negative
     if (*Snr < 0) {
         *RssiSync += *Snr;
     }


### PR DESCRIPTION
SNR (PacketSnr / 4) needs to be subtracted from RSSI when SNR is a negative value (this is similar to SX128x).

Datasheet 3.5.5:

![image](https://github.com/olliw42/sx12xx-lib/assets/41841496/daee83c4-c379-4926-92e1-0cbc8dd8fafe)