### PR TITLE
Sx126x, 10 dBm PA config

### DIFF
--- a/src/sx126x.cpp
+++ b/src/sx126x.cpp
@@ -534,8 +534,6 @@ uint8_t buf[4];
     buf[3] = SX126X_PA_CONFIG_22_DBM_PA_LUT;
 
     WriteCommand(SX126X_CMD_SET_PA_CONFIG, buf, 4);
-
-    
 }
 
 

--- a/src/sx126x.cpp
+++ b/src/sx126x.cpp
@@ -528,7 +528,7 @@ void Sx126xDriverBase::SetPaConfig_22dbm(void)
 {
 uint8_t buf[4];
 
-    buf[0] = SX126X_PA_CONFIG_PA_DUTY_CYCLE;
+    buf[0] = SX126X_PA_CONFIG_PA_DUTY_CYCLE_MAX;
     buf[1] = SX126X_PA_CONFIG_HP;
     buf[2] = SX126X_PA_CONFIG_DEVICE_SEL_SX1262;
     buf[3] = SX126X_PA_CONFIG_PA_LUT;

--- a/src/sx126x.cpp
+++ b/src/sx126x.cpp
@@ -528,7 +528,7 @@ void Sx126xDriverBase::SetPaConfig_22dbm(void)
 {
 uint8_t buf[4];
 
-    buf[0] = SX126X_PA_CONFIG_PA_DUTY_CYCLE_MAX;
+    buf[0] = SX126X_PA_CONFIG_PA_DUTY_CYCLE;
     buf[1] = SX126X_PA_CONFIG_HP;
     buf[2] = SX126X_PA_CONFIG_DEVICE_SEL_SX1262;
     buf[3] = SX126X_PA_CONFIG_PA_LUT;

--- a/src/sx126x.cpp
+++ b/src/sx126x.cpp
@@ -528,8 +528,23 @@ void Sx126xDriverBase::SetPaConfig_22dbm(void)
 {
 uint8_t buf[4];
 
-    buf[0] = SX126X_PA_CONFIG_22_DBM_PA_DUTY_CYCLE;
+    buf[0] = SX126X_PA_CONFIG_22_DBM_PA_DUTY_CYCLE_MAX;
     buf[1] = SX126X_PA_CONFIG_22_DBM_HP_MAX;
+    buf[2] = SX126X_PA_CONFIG_DEVICE_SEL_SX1262;
+    buf[3] = SX126X_PA_CONFIG_22_DBM_PA_LUT;
+
+    WriteCommand(SX126X_CMD_SET_PA_CONFIG, buf, 4);
+
+    
+}
+
+
+void Sx126xDriverBase::SetPaConfig_Min(void)
+{
+uint8_t buf[4];
+
+    buf[0] = SX126X_PA_CONFIG_22_DBM_PA_DUTY_CYCLE_MIN;
+    buf[1] = SX126X_PA_CONFIG_22_DBM_HP_MIN;
     buf[2] = SX126X_PA_CONFIG_DEVICE_SEL_SX1262;
     buf[3] = SX126X_PA_CONFIG_22_DBM_PA_LUT;
 

--- a/src/sx126x.cpp
+++ b/src/sx126x.cpp
@@ -528,10 +528,10 @@ void Sx126xDriverBase::SetPaConfig_22dbm(void)
 {
 uint8_t buf[4];
 
-    buf[0] = SX126X_PA_CONFIG_22_DBM_PA_DUTY_CYCLE_MAX;
-    buf[1] = SX126X_PA_CONFIG_22_DBM_HP_MAX;
+    buf[0] = SX126X_PA_CONFIG_PA_DUTY_CYCLE_MAX;
+    buf[1] = SX126X_PA_CONFIG_HP;
     buf[2] = SX126X_PA_CONFIG_DEVICE_SEL_SX1262;
-    buf[3] = SX126X_PA_CONFIG_22_DBM_PA_LUT;
+    buf[3] = SX126X_PA_CONFIG_PA_LUT;
 
     WriteCommand(SX126X_CMD_SET_PA_CONFIG, buf, 4);
 }
@@ -541,10 +541,10 @@ void Sx126xDriverBase::SetPaConfig_10dbm(void)
 {
 uint8_t buf[4];
 
-    buf[0] = SX126X_PA_CONFIG_22_DBM_PA_DUTY_CYCLE_MIN;
-    buf[1] = SX126X_PA_CONFIG_22_DBM_HP_MIN;
+    buf[0] = SX126X_PA_CONFIG_PA_DUTY_CYCLE_MIN;
+    buf[1] = SX126X_PA_CONFIG_HP_MIN;
     buf[2] = SX126X_PA_CONFIG_DEVICE_SEL_SX1262;
-    buf[3] = SX126X_PA_CONFIG_22_DBM_PA_LUT;
+    buf[3] = SX126X_PA_CONFIG_PA_LUT;
 
     WriteCommand(SX126X_CMD_SET_PA_CONFIG, buf, 4);
 }

--- a/src/sx126x.cpp
+++ b/src/sx126x.cpp
@@ -537,7 +537,7 @@ uint8_t buf[4];
 }
 
 
-void Sx126xDriverBase::SetPaConfig_Min(void)
+void Sx126xDriverBase::SetPaConfig_10dbm(void)
 {
 uint8_t buf[4];
 

--- a/src/sx126x.h
+++ b/src/sx126x.h
@@ -115,6 +115,7 @@ class Sx126xDriverBase
     void SetFs(void);
     void SetPaConfig(uint8_t deviceSel, uint8_t paDutyCycle, uint8_t hpMax, uint8_t paLut);
     void SetPaConfig_22dbm(void);
+    void SetPaConfig_Min(void);
     void SetRxGain(uint8_t RxGain);
     void SetTxClampConfig(void); // for workaround 15.2.2, better sensitivity
     void SetOverCurrentProtection(uint8_t OverCurrentProtection);
@@ -481,10 +482,18 @@ typedef enum {
 // cmd 0x95 SetPaConfig(uint8_t deviceSel, uint8_t paDutyCycle, uint8_t hpMax, uint8_t paLut)
 typedef enum {
     SX126X_PA_CONFIG_DEVICE_SEL_SX1262    = 0x00, // select SX1262
-    SX126X_PA_CONFIG_22_DBM_PA_DUTY_CYCLE = 0x04, // table 13-21 p. 77
-    SX126X_PA_CONFIG_22_DBM_HP_MAX        = 0x07,
     SX126X_PA_CONFIG_22_DBM_PA_LUT        = 0x01,
 } SX126X_PA_CONFIG_ENUM;
+
+typedef enum {
+    SX126X_PA_CONFIG_22_DBM_PA_DUTY_CYCLE_MAX   = 0x04, // table 13-21 p. 77
+    SX126X_PA_CONFIG_22_DBM_PA_DUTY_CYCLE_MIN   = 0x01,
+} SX126X_PA_CONFIG_DUTY_CYCLE_ENUM;
+
+typedef enum {
+    SX126X_PA_CONFIG_22_DBM_HP_MAX        = 0x07,
+    SX126X_PA_CONFIG_22_DBM_HP_MIN        = 0x01,
+} SX126X_PA_CONFIG_HP_ENUM;
 
 
 //-------------------------------------------------------

--- a/src/sx126x.h
+++ b/src/sx126x.h
@@ -485,13 +485,13 @@ typedef enum {
 } SX126X_PA_CONFIG_DEVICE_SEL_ENUM;
 
 typedef enum {
-    SX126X_PA_CONFIG_PA_DUTY_CYCLE_MIN   = 0x02, // table 13-21 p. 77
-    SX126X_PA_CONFIG_PA_DUTY_CYCLE_MAX   = 0x04, 
+    SX126X_PA_CONFIG_PA_DUTY_CYCLE_MIN   = 0x01, // table 13-21 p. 77, for 10 dBm
+    SX126X_PA_CONFIG_PA_DUTY_CYCLE_MAX   = 0x04, // for 22 dBm
 } SX126X_PA_CONFIG_DUTY_CYCLE_ENUM;
 
 typedef enum {
-    SX126X_PA_CONFIG_HP_MIN              = 0x00,
-    SX126X_PA_CONFIG_HP                  = 0x07,
+    SX126X_PA_CONFIG_HP_MIN              = 0x01, // for 10 dBm
+    SX126X_PA_CONFIG_HP                  = 0x07, // for 22 dBm
 } SX126X_PA_CONFIG_HP_ENUM;
 
 typedef enum {

--- a/src/sx126x.h
+++ b/src/sx126x.h
@@ -478,22 +478,25 @@ typedef enum {
 // PA config enum definition
 //-------------------------------------------------------
 
-// set power to max 22 dbm
 // cmd 0x95 SetPaConfig(uint8_t deviceSel, uint8_t paDutyCycle, uint8_t hpMax, uint8_t paLut)
 typedef enum {
-    SX126X_PA_CONFIG_DEVICE_SEL_SX1262    = 0x00, // select SX1262
-    SX126X_PA_CONFIG_22_DBM_PA_LUT        = 0x01,
-} SX126X_PA_CONFIG_ENUM;
+    SX126X_PA_CONFIG_DEVICE_SEL_SX1262   = 0x00,
+    SX126X_PA_CONFIG_DEVICE_SEL_SX1261   = 0x01,
+} SX126X_PA_CONFIG_DEVICE_SEL_ENUM;
 
 typedef enum {
-    SX126X_PA_CONFIG_22_DBM_PA_DUTY_CYCLE_MAX   = 0x04, // table 13-21 p. 77
-    SX126X_PA_CONFIG_22_DBM_PA_DUTY_CYCLE_MIN   = 0x01,
+    SX126X_PA_CONFIG_PA_DUTY_CYCLE_MIN   = 0x02, // table 13-21 p. 77
+    SX126X_PA_CONFIG_PA_DUTY_CYCLE_MAX   = 0x04, 
 } SX126X_PA_CONFIG_DUTY_CYCLE_ENUM;
 
 typedef enum {
-    SX126X_PA_CONFIG_22_DBM_HP_MAX        = 0x07,
-    SX126X_PA_CONFIG_22_DBM_HP_MIN        = 0x01,
+    SX126X_PA_CONFIG_HP_MIN              = 0x00,
+    SX126X_PA_CONFIG_HP                  = 0x07,
 } SX126X_PA_CONFIG_HP_ENUM;
+
+typedef enum {
+    SX126X_PA_CONFIG_PA_LUT              = 0x01,
+} SX126X_PA_CONFIG_LUT_ENUM;
 
 
 //-------------------------------------------------------

--- a/src/sx126x.h
+++ b/src/sx126x.h
@@ -115,7 +115,7 @@ class Sx126xDriverBase
     void SetFs(void);
     void SetPaConfig(uint8_t deviceSel, uint8_t paDutyCycle, uint8_t hpMax, uint8_t paLut);
     void SetPaConfig_22dbm(void);
-    void SetPaConfig_Min(void);
+    void SetPaConfig_10dbm(void);
     void SetRxGain(uint8_t RxGain);
     void SetTxClampConfig(void); // for workaround 15.2.2, better sensitivity
     void SetOverCurrentProtection(uint8_t OverCurrentProtection);


### PR DESCRIPTION
Title, allows for lower power levels on hardware with SE2435L RF front-end.

Will submit corresponding update to main mLRS branch if/when merged.