### PR TITLE
LR11xx low power pa def

### DIFF
--- a/src/lr11xx.cpp
+++ b/src/lr11xx.cpp
@@ -245,14 +245,14 @@ uint32_t Lr11xxDriverBase::GetAndClearIrqStatus(uint32_t IrqToClear)
 
 // Tx methods
 
-void Lr11xxDriverBase::SetPaConfig(uint8_t PaSel, uint8_t RegPaSupply, uint8_t PaDutyCycle, uint8_t PaHPsel)
+void Lr11xxDriverBase::SetPaConfig(uint8_t PaSel, uint8_t RegPaSupply, uint8_t PaDutyCycle, uint8_t PaHPSel)
 {
 uint8_t buf[4];
 
     buf[0] = PaSel;
     buf[1] = RegPaSupply;
     buf[2] = PaDutyCycle;
-    buf[3] = PaHPsel;
+    buf[3] = PaHPSel;
 
     WriteCommand(LR11XX_CMD_SET_PA_CONFIG, buf, 4);
 }

--- a/src/lr11xx.h
+++ b/src/lr11xx.h
@@ -85,7 +85,7 @@ class Lr11xxDriverBase
 
     // Tx methods
     
-    void SetPaConfig(uint8_t PaSel, uint8_t RegPaSupply, uint8_t PaDutyCycle, uint8_t PaHPsel); // needed before SetTxParams 9.5.1
+    void SetPaConfig(uint8_t PaSel, uint8_t RegPaSupply, uint8_t PaDutyCycle, uint8_t PaHPSel); // needed before SetTxParams 9.5.1
     void SetTxParams(uint8_t Power, uint8_t RampTime);
     void SetTx(uint32_t TxTimeout); // 24 bits only, similar to sx126x
 
@@ -416,7 +416,7 @@ typedef enum {
 // Enum Definitions Tx
 //-------------------------------------------------------
 
-// cmd 0x0215 void SetPaConfig(uint8_t PaSel, uint8_t RegPaSupply, uint8_t PaDutyCycle, uint8_t PaHPsel)
+// cmd 0x0215 void SetPaConfig(uint8_t PaSel, uint8_t RegPaSupply, uint8_t PaDutyCycle, uint8_t PaHPSel)
 typedef enum {
     LR11XX_PA_SELECT_LP_PA                = 0x00, // table 9-4, page 102
     LR11XX_PA_SELECT_HP_PA                = 0x01, 
@@ -429,12 +429,12 @@ typedef enum {
 } LR11XX_REG_PA_SUPPLY_ENUM;
 
 typedef enum {
-    LR11XX_PA_CONFIG_22_DBM_PA_DUTY_CYCLE = 0x04, // to be used with high power PA
-    LR11XX_PA_CONFIG_14_DBM_PA_DUTY_CYCLE = 0x07, // to be used with low power PA
+    LR11XX_PA_DUTY_CYCLE_22_DBM           = 0x04, // to be used with high power PA
+    LR11XX_PA_DUTY_CYCLE_14_DBM           = 0x07, // to be used with low power PA
 } LR11XX_PA_DUTY_CYCLE_ENUM;
 
 typedef enum {
-    LR11XX_PA_CONFIG_22_DBM_HP_MAX        = 0x07, // this setting only affects the high power PA
+    LR11XX_PA_HP_SEL_22_DBM               = 0x07, // this setting only affects the high power PA
 } LR11XX_PA_HP_SEL_ENUM;
 
 // cmd 0x0211 void SetTxParams(uint8_t Power, uint8_t RampTime)

--- a/src/lr11xx.h
+++ b/src/lr11xx.h
@@ -421,7 +421,7 @@ typedef enum {
     LR11XX_PA_SELECT_LP_PA                = 0x00, // table 9-4, page 102
     LR11XX_PA_SELECT_HP_PA                = 0x01, 
     LR11XX_PA_SELECT_HF_PA                = 0x02,
-} LR11XX_PA_SELECT_ENUM;
+} LR11XX_PA_SEL_ENUM;
 
 typedef enum {
     LR11XX_REG_PA_SUPPLY_INTERNAL         = 0x00, // table 9-4, page 102
@@ -435,7 +435,7 @@ typedef enum {
 
 typedef enum {
     LR11XX_PA_CONFIG_22_DBM_HP_MAX        = 0x07, // this setting only affects the high power PA
-} LR11XX_PA_HP_PA_SIZE_ENUM;
+} LR11XX_PA_HP_SEL_ENUM;
 
 // cmd 0x0211 void SetTxParams(uint8_t Power, uint8_t RampTime)
 typedef enum {

--- a/src/lr11xx.h
+++ b/src/lr11xx.h
@@ -424,15 +424,18 @@ typedef enum {
 } LR11XX_PA_SELECT_ENUM;
 
 typedef enum {
-    LR11XX_REG_PA_SUPPLY_INTERNAL          = 0x00, // table 9-4, page 102
-    LR11XX_REG_PA_SUPPLY_VBAT              = 0x01, 
+    LR11XX_REG_PA_SUPPLY_INTERNAL         = 0x00, // table 9-4, page 102
+    LR11XX_REG_PA_SUPPLY_VBAT             = 0x01, 
 } LR11XX_REG_PA_SUPPLY_ENUM;
 
 typedef enum {
-    LR11XX_PA_CONFIG_22_DBM_PA_DUTY_CYCLE = 0x04, // table 9-4, page 102
-    LR11XX_PA_CONFIG_14_DBM_PA_DUTY_CYCLE = 0x07,
-    LR11XX_PA_CONFIG_22_DBM_HP_MAX        = 0x07, // comes from sx126x, user manual is vague
-} LR11XX_PA_CONFIG_ENUM;
+    LR11XX_PA_CONFIG_22_DBM_PA_DUTY_CYCLE = 0x04, // to be used with high power PA
+    LR11XX_PA_CONFIG_14_DBM_PA_DUTY_CYCLE = 0x07, // to be used with low power PA
+} LR11XX_PA_DUTY_CYCLE_ENUM;
+
+typedef enum {
+    LR11XX_PA_CONFIG_22_DBM_HP_MAX        = 0x07, // this setting only affects the high power PA
+} LR11XX_PA_HP_PA_SIZE_ENUM;
 
 // cmd 0x0211 void SetTxParams(uint8_t Power, uint8_t RampTime)
 typedef enum {

--- a/src/lr11xx.h
+++ b/src/lr11xx.h
@@ -439,22 +439,22 @@ typedef enum {
 
 // cmd 0x0211 void SetTxParams(uint8_t Power, uint8_t RampTime)
 typedef enum {
-    LR11XX_RAMPTIME_16_US                  = 0x00, // table 9-7, page 103
-    LR11XX_RAMPTIME_32_US                  = 0x01,
-    LR11XX_RAMPTIME_48_US                  = 0x02, // recommended by user manual
-    LR11XX_RAMPTIME_64_US                  = 0x03,
-    LR11XX_RAMPTIME_80_US                  = 0x04,
-    LR11XX_RAMPTIME_96_US                  = 0x05,
-    LR11XX_RAMPTIME_112_US                 = 0x06,
-    LR11XX_RAMPTIME_128_US                 = 0x07,
-    LR11XX_RAMPTIME_144_US                 = 0x08,
-    LR11XX_RAMPTIME_160_US                 = 0x09,
-    LR11XX_RAMPTIME_176_US                 = 0x0A,
-    LR11XX_RAMPTIME_192_US                 = 0x0B,
-    LR11XX_RAMPTIME_208_US                 = 0x0C,
-    LR11XX_RAMPTIME_240_US                 = 0x0D,
-    LR11XX_RAMPTIME_272_US                 = 0x0E,
-    LR11XX_RAMPTIME_304_US                 = 0x0F,
+    LR11XX_RAMPTIME_16_US                 = 0x00, // table 9-7, page 103
+    LR11XX_RAMPTIME_32_US                 = 0x01,
+    LR11XX_RAMPTIME_48_US                 = 0x02, // recommended by user manual
+    LR11XX_RAMPTIME_64_US                 = 0x03,
+    LR11XX_RAMPTIME_80_US                 = 0x04,
+    LR11XX_RAMPTIME_96_US                 = 0x05,
+    LR11XX_RAMPTIME_112_US                = 0x06,
+    LR11XX_RAMPTIME_128_US                = 0x07,
+    LR11XX_RAMPTIME_144_US                = 0x08,
+    LR11XX_RAMPTIME_160_US                = 0x09,
+    LR11XX_RAMPTIME_176_US                = 0x0A,
+    LR11XX_RAMPTIME_192_US                = 0x0B,
+    LR11XX_RAMPTIME_208_US                = 0x0C,
+    LR11XX_RAMPTIME_240_US                = 0x0D,
+    LR11XX_RAMPTIME_272_US                = 0x0E,
+    LR11XX_RAMPTIME_304_US                = 0x0F,
 } LR11XX_RAMPTIME_ENUM;
 
 // added for convenience

--- a/src/lr11xx.h
+++ b/src/lr11xx.h
@@ -430,8 +430,9 @@ typedef enum {
 
 typedef enum {
     LR11XX_PA_CONFIG_22_DBM_PA_DUTY_CYCLE = 0x04, // table 9-4, page 102
+    LR11XX_PA_CONFIG_14_DBM_PA_DUTY_CYCLE = 0x07, // table 9-4, page 102
     LR11XX_PA_CONFIG_22_DBM_HP_MAX        = 0x07, // comes from sx126x, user manual is vague
-} LR11XX_PA_PA_CONFIG_ENUM;
+} LR11XX_PA_CONFIG_ENUM;
 
 // cmd 0x0211 void SetTxParams(uint8_t Power, uint8_t RampTime)
 typedef enum {

--- a/src/lr11xx.h
+++ b/src/lr11xx.h
@@ -430,7 +430,7 @@ typedef enum {
 
 typedef enum {
     LR11XX_PA_CONFIG_22_DBM_PA_DUTY_CYCLE = 0x04, // table 9-4, page 102
-    LR11XX_PA_CONFIG_14_DBM_PA_DUTY_CYCLE = 0x07, // table 9-4, page 102
+    LR11XX_PA_CONFIG_14_DBM_PA_DUTY_CYCLE = 0x07,
     LR11XX_PA_CONFIG_22_DBM_HP_MAX        = 0x07, // comes from sx126x, user manual is vague
 } LR11XX_PA_CONFIG_ENUM;
 


### PR DESCRIPTION
- Adds another definition for the low power PA duty cycle (Radiomaster Nomad uses)
- Removes duplicate 'pa' from the enum name