### PR TITLE
LR11xx updates

### DIFF
--- a/src/lr11xx.cpp
+++ b/src/lr11xx.cpp
@@ -59,7 +59,7 @@ ALIGNED uint8_t rxData[WORD_PAD(len + 2)];
 }
 
 
-void Lr11xxDriverBase::ReadStatus(uint8_t* data)
+void Lr11xxDriverBase::ReadStatus(uint8_t* data)  // status is unique, so provide a special function
 {
 ALIGNED uint8_t txData[8] = {0};
 ALIGNED uint8_t rxData[8];
@@ -81,7 +81,7 @@ ALIGNED uint8_t rxData[8];
 
 void Lr11xxDriverBase::ReadCommand(uint16_t opcode, uint8_t* data, uint8_t len)
 {
-ALIGNED uint8_t txData[4] = {0};
+ALIGNED uint8_t txData[4] = {0};  // minimum of four bytes
 ALIGNED uint8_t rxData[4];
 ALIGNED uint8_t buffer[WORD_PAD(len + 1)];
 
@@ -90,11 +90,11 @@ ALIGNED uint8_t buffer[WORD_PAD(len + 1)];
 
     WaitOnBusy();
     SpiSelect();
-    SpiTransfer(txData, rxData, 4);
+    SpiTransfer(txData, rxData, 2);
     SpiDeselect(); 
     WaitOnBusy();
     SpiSelect();
-    SpiRead(buffer, len + 1);
+    SpiRead(buffer, len + 1);  // could do transfer again, but need another buffer
     SpiDeselect();
 
     _status1 = rxData[0];
@@ -126,7 +126,7 @@ ALIGNED uint8_t rxData[WORD_PAD(len + 2)];
 
 void Lr11xxDriverBase::ReadBuffer(uint8_t offset, uint8_t* data, uint8_t len)
 {
-ALIGNED uint8_t txData[4] = {0};
+ALIGNED uint8_t txData[4] = {0};  // minimum of four bytes
 ALIGNED uint8_t rxData[4];
 ALIGNED uint8_t buffer[WORD_PAD(len + 1)];
 
@@ -141,7 +141,7 @@ ALIGNED uint8_t buffer[WORD_PAD(len + 1)];
     SpiDeselect(); 
     WaitOnBusy();
     SpiSelect();
-    SpiRead(buffer, len + 1); // could do transfer again, but need another buffer
+    SpiRead(buffer, len + 1);  // could do transfer again, but need another buffer
     SpiDeselect();
 
     _status1 = rxData[0];
@@ -155,8 +155,8 @@ ALIGNED uint8_t buffer[WORD_PAD(len + 1)];
 
 void Lr11xxDriverBase::GetStatus(uint8_t* Status1, uint8_t* Status2)
 {
-    WriteCommand(LR11XX_CMD_GET_STATUS);  // don't need a response, so don't need to use ReadCommand 
-
+    ReadStatus(nullptr);
+    
     *Status1 = _status1;
     *Status2 = _status2;
 }

--- a/src/lr11xx.cpp
+++ b/src/lr11xx.cpp
@@ -141,13 +141,13 @@ ALIGNED uint8_t buffer[WORD_PAD(len + 1)];
     SpiDeselect(); 
     WaitOnBusy();
     SpiSelect();
-    SpiRead(buffer, len + 1); // Perform a single SPI read
+    SpiRead(buffer, len + 1); // could do transfer again, but need another buffer
     SpiDeselect();
 
     _status1 = rxData[0];
     _status2 = rxData[1];
 
-    memcpy(data, &buffer[1], len); // Copy the rest into the data buffer
+    memcpy(data, &buffer[1], len);
 }
 
 

--- a/src/lr11xx.cpp
+++ b/src/lr11xx.cpp
@@ -83,7 +83,7 @@ void Lr11xxDriverBase::ReadCommand(uint16_t opcode, uint8_t* data, uint8_t len)
 {
 ALIGNED uint8_t txData[4] = {0};  // minimum of four bytes
 ALIGNED uint8_t rxData[4];
-ALIGNED uint8_t buffer[WORD_PAD(len + 1)];
+ALIGNED uint8_t buffer[WORD_PAD(len)];
 
     txData[0] = (uint8_t)((opcode & 0xFF00) >> 8);  // opcode high byte
     txData[1] = (uint8_t)(opcode & 0x00FF);         // opcode low byte
@@ -94,13 +94,13 @@ ALIGNED uint8_t buffer[WORD_PAD(len + 1)];
     SpiDeselect(); 
     WaitOnBusy();
     SpiSelect();
-    SpiRead(buffer, len + 1);  // could do transfer again, but need another buffer
+    SpiRead(buffer, len);  // could do transfer again, but need another buffer
     SpiDeselect();
 
     _status1 = rxData[0];
     _status2 = rxData[1];
 
-    memcpy(data, &buffer[1], len);
+    memcpy(data, &buffer[0], len);
 }
 
 
@@ -526,7 +526,7 @@ uint8_t status[5];
 
     // position 0 is status1, again
 
-    ReadCommand(LR11XX_CMD_GET_PACKET_STATUS, status, 3);
+    ReadCommand(LR11XX_CMD_GET_PACKET_STATUS, status, 5);
 
     *RssiSync = -(int16_t)(status[1] / 2);
 }

--- a/src/lr11xx.h
+++ b/src/lr11xx.h
@@ -24,6 +24,7 @@
 #define ALIGNED  __attribute__((aligned(4)))
 #endif
 
+#define WORD_PAD(size) (((size)+3) & ~3)
 
 //-------------------------------------------------------
 // Base Class
@@ -59,6 +60,7 @@ class Lr11xxDriverBase
     // low level methods, usually no need to use them
 
     void WriteCommand(uint16_t opcode, uint8_t* data, uint8_t len);
+    void ReadStatus(uint8_t* data);
     void ReadCommand(uint16_t opcode, uint8_t* data, uint8_t len);
     void WriteBuffer(uint8_t* data, uint8_t len);
     void ReadBuffer(uint8_t offset, uint8_t* data, uint8_t len);


### PR DESCRIPTION
This is working but will leave in draft for feedback.

Primary motivation is to help with ESP platform:

- Word aligned all the buffers
- Word pad all the buffers
- Minimize SPI transactions

Each SPI transaction on ESP32 has 3 uS of overhead between bytes, so when sending the opcode with two spiTransfer calls at 16 MHz means 4 uS (2 * 0.5 uS + 3 uS).  Sending with a single spiTransfer means 1 uS (2 * 0.5 uS).