### PR TITLE
LR2021 GetLoraPacketStatus Update

### DIFF
--- a/src/lr20xx.cpp
+++ b/src/lr20xx.cpp
@@ -620,7 +620,7 @@ uint8_t buf[8];
     *Crc = ((buf[2] & 0x10) << 1);
     *CR = (buf[2] & 0x0F);
     *PktLen = buf[3];
-    *Snr = (int8_t)buf[4];
+    *Snr = (int8_t)buf[4] / 4; // snr_pkt is in 1/4 dB
     *Rssi = (int16_t)(((uint16_t)buf[5] << 1) + (((uint16_t)buf[7] & 0x02) >> 1));
     *RssiSignal = (int16_t)(((uint16_t)buf[6] << 1) + ((uint16_t)buf[7] & 0x01));
     *Detector = (buf[7] & 0x3D) >> 2;
@@ -632,7 +632,7 @@ uint8_t buf[8];
 
     ReadCommand(LR20XX_CMD_GET_LORA_PACKET_STATUS, buf, 8);
 
-    *Snr = (int8_t)buf[4];
+    *Snr = (int8_t)buf[4] / 4; // snr_pkt is in 1/4 dB
     *Rssi = (int16_t)(((uint16_t)buf[5] << 1) + (((uint16_t)buf[7] & 0x02) >> 1));
     *RssiSignal = (int16_t)(((uint16_t)buf[6] << 1) + ((uint16_t)buf[7] & 0x01));
 }

--- a/src/lr20xx.cpp
+++ b/src/lr20xx.cpp
@@ -617,13 +617,13 @@ uint8_t buf[8];
 
     ReadCommand(LR20XX_CMD_GET_LORA_PACKET_STATUS, buf, 8);
 
-    *Crc = ((buf[2] & 0x10) << 1);
+    *Crc = ((buf[2] & 0x10) >> 4);
     *CR = (buf[2] & 0x0F);
     *PktLen = buf[3];
     *Snr = (int8_t)buf[4] / 4; // snr_pkt is in 1/4 dB
     *Rssi = (int16_t)(((uint16_t)buf[5] << 1) + (((uint16_t)buf[7] & 0x02) >> 1));
     *RssiSignal = (int16_t)(((uint16_t)buf[6] << 1) + ((uint16_t)buf[7] & 0x01));
-    *Detector = (buf[7] & 0x3D) >> 2;
+    *Detector = (buf[7] & 0x3C) >> 2;
 }
 
 void Lr20xxDriverBase::GetLoraPacketStatus(int16_t* Rssi, int16_t* RssiSignal, int8_t* Snr)


### PR DESCRIPTION
Should be divided by 4, per the Datasheet:

<img width="840" height="61" alt="image" src="https://github.com/user-attachments/assets/cdccbf12-f1fd-47c4-bc7e-126887d92983" />